### PR TITLE
Fixed webpack build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "font-manager",
   "version": "0.2.2",
   "description": "Provides access to the system font catalog",
-  "main": "build/Release/fontmanager",
+  "main": "build/Release/fontmanager.node",
   "dependencies": {
     "nan": "~2.2.0"
   },


### PR DESCRIPTION
Webpack was freaking out because it didn't know how to interpret the file that `main` was pointing to.

This change specifies what the file type is so you can add a loader for webpack to interpret the `.node` file type