### PR TITLE
fix crash due to some fonts having family null

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Provides access to the system font catalog",
   "main": "build/Release/fontmanager",
   "dependencies": {
-    "nan": "~2.2.0"
+    "nan": "^2.11.0"
   },
   "devDependencies": {
     "mocha": "*"

--- a/src/FontManagerMac.mm
+++ b/src/FontManagerMac.mm
@@ -78,6 +78,11 @@ ResultSet *getAvailableFonts() {
   ResultSet *results = new ResultSet();
   
   for (id m in matches) {
+    NSString *family = (NSString *) CTFontDescriptorCopyAttribute((CTFontDescriptorRef) m, kCTFontFamilyNameAttribute);
+    if (family == NULL) {
+      continue;
+    }
+    
     CTFontDescriptorRef match = (CTFontDescriptorRef) m;
     results->push_back(createFontDescriptor(match));
   }
@@ -167,6 +172,11 @@ ResultSet *findFonts(FontDescriptor *desc) {
   }];
   
   for (id m in sorted) {
+    NSString *family = (NSString *) CTFontDescriptorCopyAttribute((CTFontDescriptorRef) m, kCTFontFamilyNameAttribute);
+    if (family == NULL) {
+      continue;
+    }
+    
     CTFontDescriptorRef match = (CTFontDescriptorRef) m;
     int mb = metricForMatch((CTFontDescriptorRef) m, desc);
     
@@ -186,6 +196,11 @@ CTFontDescriptorRef findBest(FontDescriptor *desc, NSArray *matches) {
   int bestMetric = INT_MAX;
 
   for (id m in matches) {
+    NSString *family = (NSString *) CTFontDescriptorCopyAttribute((CTFontDescriptorRef) m, kCTFontFamilyNameAttribute);
+    if (family == NULL) {
+      continue;
+    }
+    
     int metric = metricForMatch((CTFontDescriptorRef) m, desc);
 
     if (metric < bestMetric) {


### PR DESCRIPTION
we had some issues with some fonts that had "null" family and caused the app (electron) to crash, this fixes it. I'm not experienced with Objective-C so feel free to reject this PR and do a better fix if there is a better solution.

Thanks