### PR TITLE
Bump nan version to support Node 10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Provides access to the system font catalog",
   "main": "build/Release/fontmanager",
   "dependencies": {
-    "nan": "~2.2.0"
+    "nan": ">=2.10.0"
   },
   "devDependencies": {
     "mocha": "*"

--- a/src/FontManager.cc
+++ b/src/FontManager.cc
@@ -79,6 +79,7 @@ struct AsyncRequest {
 void asyncCallback(uv_work_t *work) {
   Nan::HandleScope scope;
   AsyncRequest *req = (AsyncRequest *) work->data;
+  Nan::AsyncResource async("asyncCallback");
   Local<Value> info[1];
 
   if (req->results) {
@@ -89,7 +90,7 @@ void asyncCallback(uv_work_t *work) {
     info[0] = Nan::Null();
   }
 
-  req->callback->Call(1, info);
+  req->callback->Call(1, info, &async);
   delete req;
 }
 


### PR DESCRIPTION
This raises the requirement for [nan](https://github.com/nodejs/nan) to 2.10.0 or greater, to support the latest node.js.
