### PR TITLE
Don't need to run node-gyp rebuild in install

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "mocha",
-    "install": "node-gyp rebuild"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Node-gyp build will be called automatically by npm / yarn on install for native modules with a binding.gyp.